### PR TITLE
add stricter regexp to detect node interfaces

### DIFF
--- a/hwdet-init.sh
+++ b/hwdet-init.sh
@@ -14,11 +14,11 @@ HW_FILE=$CONF_DIR/rtr-hw.txt
 SW_FILE=$CONF_DIR/rtr-sw.txt
 
 # wait for all node interfaces to come up
-NODE_INTFS=`ip -o link show | grep -P 'eth[1-9]\d?' | wc -l`
+NODE_INTFS=`ip -o link show | grep -P 'eth[1-9]\d?@' | wc -l`
 while (( $NODE_INTFS != $CLAB_INTFS ))  
 do
   sleep 1
-  NODE_INTFS=`ip -o link show | grep -P 'eth[1-9]\d?' | wc -l`
+  NODE_INTFS=`ip -o link show | grep -P 'eth[1-9]\d?@' | wc -l`
 done
 
 if [ ! -d "$CONF_DIR" ] ; then

--- a/hwdet-init.sh
+++ b/hwdet-init.sh
@@ -14,11 +14,11 @@ HW_FILE=$CONF_DIR/rtr-hw.txt
 SW_FILE=$CONF_DIR/rtr-sw.txt
 
 # wait for all node interfaces to come up
-NODE_INTFS=`ip -o link show | grep eth | grep -v eth0 | wc -l`
+NODE_INTFS=`ip -o link show | grep -P 'eth[1-9]\d?' | wc -l`
 while (( $NODE_INTFS != $CLAB_INTFS ))  
 do
   sleep 1
-  NODE_INTFS=`ip -o link show | grep eth | grep -v eth0 | wc -l`
+  NODE_INTFS=`ip -o link show | grep -P 'eth[1-9]\d?' | wc -l`
 done
 
 if [ ! -d "$CONF_DIR" ] ; then


### PR DESCRIPTION
Current node interface detection pattern matches `gretap` and `erspan` interfaces which leads to either:
* init loop because the matching line count is not equal to clab interfaces count
* when clab interface count == 2, the init will possibly start without the real eth interfaces ready and they will never be initialized

This made freertr deployment behave erratically on my clabernetes cluster which includes erspan/gretap.

Old pattern
```
~# ip -o link show | grep eth | grep -v eth0
3: gretap0@NONE: <BROADCAST,MULTICAST> mtu 1462 qdisc noop state DOWN mode DEFAULT group default qlen 1000\    link/ether 00:00:00:00:00:00 brd ff:ff:ff:ff:ff:ff
4: erspan0@NONE: <BROADCAST,MULTICAST> mtu 1450 qdisc noop state DOWN mode DEFAULT group default qlen 1000\    link/ether 00:00:00:00:00:00 brd ff:ff:ff:ff:ff:ff
14: eth1@if13: <BROADCAST,MULTICAST,PROMISC,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default \    link/ether aa:c1:ab:12:47:93 brd ff:ff:ff:ff:ff:ff link-netnsid 0
16: eth2@if15: <BROADCAST,MULTICAST,PROMISC,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default \    link/ether aa:c1:ab:95:30:3c brd ff:ff:ff:ff:ff:ff link-netnsid 0
```

New pattern
```
~# ip -o link show | grep -P 'eth[1-9]\d?@'
14: eth1@if13: <BROADCAST,MULTICAST,PROMISC,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default \    link/ether aa:c1:ab:12:47:93 brd ff:ff:ff:ff:ff:ff link-netnsid 0
16: eth2@if15: <BROADCAST,MULTICAST,PROMISC,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default \    link/ether aa:c1:ab:95:30:3c brd ff:ff:ff:ff:ff:ff link-netnsid 0
```
