### PR TITLE
Improve IP address extraction for the mgmt interface

### DIFF
--- a/hwdet-mgmt.sh
+++ b/hwdet-mgmt.sh
@@ -14,9 +14,9 @@ CONF_DIR=$RUN_DIR/conf
 
 ETH0_MAC=`cat /sys/class/net/eth0/address`
 HOSTNAME=`hostname`
-IPv4=`hostname -i | awk '{print $1}'`
-IPv6=`hostname -i | awk '{print $2}'`
-
+IPv4=$(hostname -i | awk '{for(i=1;i<=NF;i++) if($i ~ /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/) {print $i; exit}}')
+IPv6=$(hostname -i | awk '{for(i=1;i<=NF;i++) if($i ~ /^[0-9a-fA-F:]+$/) {print $i; exit}}')
+ 
 # Identify the end of freeRtr hw|sw file
 
 HW_PENULTIMATE_LINE=`wc -l ${CONF_DIR}/rtr-hw.txt | awk '{print $1}'`


### PR DESCRIPTION
Reworked the extraction of IPv4 and IPv6 addresses from `hostname -i` to handle cases where the address order is inconsistent. Previously, the script relied on fixed positional parameters (`$1` for IPv4 and `$2` for IPv6), which caused issues when the order changed. 

The updated implementation uses `awk` with regular expressions to dynamically match and extract the correct IPv4 and IPv6 addresses, ensuring correct assignment regardless of their position in the output.