### PR TITLE
Dataplane type pcapint or p4emu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ COPY ./install-deps.sh /root
 COPY ./install-rtr.sh /root
 COPY ./install-clean.sh /root
 
+# Set default dataplane type (pcapInt or p4emu)
+ENV DATAPLANE_TYPE=pcapInt
 
 RUN ./install-deps.sh
 RUN ./install-rtr.sh

--- a/README.md
+++ b/README.md
@@ -36,6 +36,34 @@ The lab definition file is `rtr000.clab.yml`
 ```
 rtr1 <--eth1--> rtr2
 ``` 
+
+* Dataplane Configuration
+
+You can configure the dataplane type for each router using the `DATAPLANE_TYPE` environment variable in the containerlab topology file. The available options are:
+
+- `pcapInt` (default): Uses the standard packet capture interface
+- `p4emu`: Uses the P4 emulation interface
+
+Example configuration in `rtr000.clab.yml`:
+```yaml
+name: rtr000
+
+topology:
+  nodes:
+    rtr1:
+      kind: rare
+      image: ghcr.io/rare-freertr/freertr-containerlab:latest
+      env:
+        DATAPLANE_TYPE: "p4emu"
+    rtr2:
+      kind: rare
+      image: ghcr.io/rare-freertr/freertr-containerlab:latest
+      env:
+        DATAPLANE_TYPE: "p4emu"
+  links:
+    - endpoints: ["rtr1:eth1","rtr2:eth1"]
+```
+
 * Artefact folder for each node will be created during lab initialisation (e.g `rtr1` and `rtr2`)
 
 Which format is clab-`lab-name`/`node-name`/run

--- a/hwdet-init.sh
+++ b/hwdet-init.sh
@@ -13,6 +13,143 @@ MRT_DIR=$RUN_DIR/mrt
 HW_FILE=$CONF_DIR/rtr-hw.txt
 SW_FILE=$CONF_DIR/rtr-sw.txt
 
+# default dataplane type
+DATAPLANE_TYPE=${DATAPLANE_TYPE:-pcapInt}
+
+# Function
+initialize_pcapInt() {
+  [ -L "$CONF_DIR/pcapInt.bin" ] || ln -s $TRG/pcapInt.bin $CONF_DIR/pcapInt.bin
+}
+
+initialize_p4emu() {
+  [ -L "$CONF_DIR/pcapInt.bin" ] || ln -s $TRG/pcapInt.bin $CONF_DIR/pcapInt.bin
+  [ -L "$CONF_DIR/p4emu.bin" ] || ln -s $TRG/p4emu.bin $CONF_DIR/p4emu.bin
+  [ -L "$CONF_DIR/libp4emu_pcap.so" ] || ln -sf $TRG/libp4emu_pcap.so $CONF_DIR/libp4emu_pcap.so
+  [ -L "$CONF_DIR/libp4emu_full.so" ] || ln -sf $TRG/libp4emu_full.so $CONF_DIR/libp4emu_full.so
+}
+prepare_p4emu_hw_file() {
+HW_FILE_INSERT_AFTER_LINE="tcp2vrf 2323 OOB 23"
+VETH_CPU_PORT_B=`cat /sys/class/net/eth0/address`
+HW_FILE_LINES_TO_ADD=(
+  "tcp2vrf 9080 p4 9080"
+  "int eth0 eth ${VETH_CPU_PORT_B} 127.0.0.1 20001 127.0.0.1 20002"
+  "proc cpu_port_0 $CONF_DIR/pcapInt.bin veth_cpu_port_b 20002 127.0.0.1 20001 127.0.0.1"
+  "proc p4emu $CONF_DIR/p4emu.bin 127.0.0.1 9080 0 veth_cpu_port_a $INTERFACES_SPACE"
+)
+
+for (( idx=${#HW_FILE_LINES_TO_ADD[@]}-1 ; idx>=0 ; idx-- )) ; do
+  line="${HW_FILE_LINES_TO_ADD[idx]}"
+  if ! awk -v pat="$line" '$0 == pat { found=1 } END { exit !found }' "$HW_FILE"; then
+    sed -i "/^${HW_FILE_INSERT_AFTER_LINE//\//\\/}\$/a $line" "$HW_FILE"
+  fi
+done
+sed -i '$a\\' "$HW_FILE"
+}
+prepare_p4emu_sw_file() {
+sed -i -E 's/ethernet([0-9]+)/sdn\1/g' "$SW_FILE"
+sed -i -E 's/sdn0/ethernet0/g; s/sdn255/ethernet255/g' "$SW_FILE"
+}
+prepare_pcapInt_sw_file() {
+sed -i -E 's/sdn([0-9]+)/ethernet\1/g' "$SW_FILE"
+}
+create_sdn_interfaces_sw_file() {
+for INTF in "${INTERFACES_ARRAY[@]}"; do
+  INTF_NUM=${INTF#eth}
+
+  ed -s "$SW_FILE" <<EOF
+/^interface sdn${INTF_NUM}\$/,/^!$/p
+q
+EOF
+
+  if [ $? -ne 0 ]; then
+    ed -s "$SW_FILE" <<EOC
+\$a
+interface sdn${INTF_NUM}
+ exit
+!
+.
+w
+q
+EOC
+  fi
+done
+} 
+
+delete_vrf_p4_sw_file() {
+sed -i '/^vrf definition p4$/,/^!$/d' "$SW_FILE"
+}
+
+delete_p4_server_sw_file() {
+sed -i '/^server p4lang p4$/,/^!$/d' "$SW_FILE"
+}
+
+
+
+create_vrf_p4_sw_file() {
+if ! ed -s "$SW_FILE" <<'EOF'
+/^vrf definition p4$/,/^ exit$/p
+q
+EOF
+then
+  ed -s "$SW_FILE" <<'EOC'
+$a
+vrf definition p4
+ exit
+.
+w
+q
+EOC
+fi
+}
+
+create_p4_server_sw_file() {
+if ! ed -s "$SW_FILE" <<'EOF'
+/^server p4lang p4$/,/^ exit$/p
+q
+EOF
+then
+  ed -s "$SW_FILE" <<'EOC'
+$a
+server p4lang p4
+ interconnect ethernet0
+ vrf p4
+ exit
+.
+w
+q
+EOC
+fi
+}
+export_ports_p4_server_interfaces_sw_file() {
+for INTF in "${INTERFACES_ARRAY[@]}"; do
+  INTF_NUM=${INTF#eth}
+  EXPORT_PORT="export-port sdn${INTF_NUM} ${INTF_NUM} 1 0 0 0"
+  ed -s "$SW_FILE" <<EOF
+/^server p4lang p4\$/,/^ exit\$/g
+  /$EXPORT_PORT/
+  -1a
+$EXPORT_PORT
+.
+w
+q
+EOF
+
+done
+}
+
+configure_interfaces_mac_sw_file() {
+for ((i=1; i<=NODE_INTFS; i++)); do
+  mac=$(cat /sys/class/net/eth$i/address | tr -d ':')
+  mac="${mac:0:4}.${mac:4:4}.${mac:8:4}"
+  if [ "$DATAPLANE_TYPE" = "pcapInt" ]; then
+    sed -i "/^interface ethernet$i\$/,/^ exit\$/s/^ macaddr .*/ macaddr $mac/" "$SW_FILE"
+  elif [ "$DATAPLANE_TYPE" = "p4emu" ]; then
+    sed -i "/^interface sdn$i\$/,/^ exit\$/s/^ macaddr .*/ macaddr $mac/" "$SW_FILE"
+  fi
+done
+}
+
+
 # wait for all node interfaces to come up
 NODE_INTFS=`ip -o link show | grep -P 'eth[1-9]\d?@' | wc -l`
 while (( $NODE_INTFS != $CLAB_INTFS ))  
@@ -20,6 +157,11 @@ do
   sleep 1
   NODE_INTFS=`ip -o link show | grep -P 'eth[1-9]\d?@' | wc -l`
 done
+
+readarray -t INTERFACES_ARRAY < <(ip -o link show | awk -F': ' '{print $2}' | sed 's/@.*//' | grep '^eth[1-9][0-9]*$' | sort -V)
+INTERFACES_SPACE="${INTERFACES_ARRAY[*]}"
+INTERFACES_SLASHES="/$(IFS=/; echo "${INTERFACES_ARRAY[*]}")/"
+
 
 if [ ! -d "$CONF_DIR" ] ; then
   echo "Creating freeRtr run/* folders"
@@ -30,10 +172,38 @@ cp /proc/net/dev $CONF_DIR/hwdet.eth
 cp /proc/tty/driver/serial $CONF_DIR/hwdet.ser
 ip link show > $CONF_DIR/hwdet.mac
 
+if [ "$DATAPLANE_TYPE" = "p4emu" ]; then
+  echo "Dataplane type is p4emu"
+
+  ip link add veth_cpu_port_a type veth peer name veth_cpu_port_b
+  ip link set veth_cpu_port_a up
+  ip link set veth_cpu_port_b up
+
+  ip link set veth_cpu_port_a promisc on
+  ip link set veth_cpu_port_b promisc on
+
+  ip link set dev veth_cpu_port_a up mtu 10240
+  ip link set dev veth_cpu_port_b up mtu 10240
+
+  TOE_OPTIONS="rx tx sg tso ufo gso gro lro rxvlan txvlan rxhash"
+  for TOE_OPTION in $TOE_OPTIONS; do
+    /sbin/ethtool --offload veth_cpu_port_a "$TOE_OPTION" off &> /dev/null
+    /sbin/ethtool --offload veth_cpu_port_b "$TOE_OPTION" off &> /dev/null
+    for i in $(ip -o link show | awk -F': ' '{print $2}' | sed 's/@.*//' | grep '^eth[0-9][0-9]*$'); do
+      /sbin/ethtool --offload $i "$TOE_OPTION" off &> /dev/null
+    done
+  done
+
+fi
+
 if [ ! -f "$HW_FILE" ] ; then
   cp $TRG/rtr-sw.txt $SW_FILE
   cp $TRG/rtr-hw.txt $HW_FILE
-  ln -s $TRG/pcapInt.bin $CONF_DIR/pcapInt.bin
+  if [ "$DATAPLANE_TYPE" = "pcapInt" ]; then
+    initialize_pcapInt
+  elif [ "$DATAPLANE_TYPE" = "p4emu" ]; then
+    initialize_p4emu
+  fi
 fi
 
 if [ -f "$CONF_DIR/hwdet-all.sh" ] ; then
@@ -48,8 +218,25 @@ if [ -f "$CONF_DIR/hwdet-main.sh" ] ; then
   mv $CONF_DIR/hwdet-main.sh $CONF_DIR/hwdet-main.sh.bak
 fi
 
-
 # then trigger interfaces discovery
-java -jar $TRG/rtr.jar test hwdet path $CONF_DIR/ iface pcap inline exclifc lo/tap20001/sit0/tunl0/eth0/gre0/erspan0/gretap0/ip6tnl0 mem 1024m tcpvrf 2323 OOB 23
+if [ "$DATAPLANE_TYPE" = "pcapInt" ]; then
+  initialize_pcapInt
+  prepare_pcapInt_sw_file
+  java -jar $TRG/rtr.jar test hwdet path $CONF_DIR/ iface pcap inline exclifc lo/tap20001/sit0/tunl0/eth0/gre0/erspan0/gretap0/ip6tnl0 mem 1024m tcpvrf 2323 OOB 23
+  configure_interfaces_mac_sw_file
+  delete_p4_server_sw_file
+  delete_vrf_p4_sw_file
+elif [ "$DATAPLANE_TYPE" = "p4emu" ]; then
+  initialize_p4emu
+  java -jar $TRG/rtr.jar test hwdet path $CONF_DIR/ iface pcap inline exclifc lo/tap20001/sit0/tunl0/eth0/gre0/erspan0/gretap0/ip6tnl0/veth_cpu_port_a/veth_cpu_port_b$INTERFACES_SLASHES mem 1024m tcpvrf 2323 OOB 23
+  prepare_p4emu_hw_file
+  prepare_p4emu_sw_file
+  create_sdn_interfaces_sw_file
+  configure_interfaces_mac_sw_file
+  create_vrf_p4_sw_file
+  create_p4_server_sw_file
+  export_ports_p4_server_interfaces_sw_file
+fi
+
 chmod u+x $CONF_DIR/hwdet-*.sh
 

--- a/hwdet-mgmt.sh
+++ b/hwdet-mgmt.sh
@@ -11,33 +11,29 @@ RUN_DIR=$TRG/run
 CONF_DIR=$RUN_DIR/conf
 
 # Detect eth0 network context allocated by Docker bridge
-
 ETH0_MAC=`cat /sys/class/net/eth0/address`
+ETH0_MACADDR=$(echo "$ETH0_MAC" | tr -d ':' | sed 's/\(....\)\(....\)\(....\)/\1.\2.\3/')
 HOSTNAME=`hostname`
 IPv4=$(hostname -i | awk '{for(i=1;i<=NF;i++) if($i ~ /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/) {print $i; exit}}')
 IPv6=$(hostname -i | awk '{for(i=1;i<=NF;i++) if($i ~ /^[0-9a-fA-F:]+$/) {print $i; exit}}')
- 
-# Identify the end of freeRtr hw|sw file
+
 
 HW_PENULTIMATE_LINE=`wc -l ${CONF_DIR}/rtr-hw.txt | awk '{print $1}'`
-SW_PENULTIMATE_LINE=`wc -l ${CONF_DIR}/rtr-sw.txt | awk '{print $1}'`
-
-# Insert management interface information
-# to rtr-hw.txt
-# And set it to ethernet255 
-# (Arbitrary choice ! Please change it if it bothers you !)
 
 sed -i "${HW_PENULTIMATE_LINE}i\\
 proc ifc255.sh ${CONF_DIR}/pcapInt.bin eth0 22552 127.0.0.1 22551 127.0.0.1\\
 int eth255 eth ${ETH0_MAC} 127.0.0.1 22551 127.0.0.1 22552\
 " $CONF_DIR/rtr-hw.txt
 
-# Insert management interface information
-# to rtr-sw.txt
+sed -i '${/^$/d;}' "$CONF_DIR/rtr-hw.txt"
+sed -i '$a\\' "$CONF_DIR/rtr-sw.txt"
+
+SW_PENULTIMATE_LINE=`wc -l ${CONF_DIR}/rtr-sw.txt | awk '{print $1}'`
 
 sed -i "${SW_PENULTIMATE_LINE}i\\
 hostname ${HOSTNAME}\\
 interface ethernet255\\
+ macaddr ${ETH0_MACADDR} \\
  vrf forwarding OOB\\
  ipv4 address ${IPv4} /24\\
  ipv6 address ${IPv6} /64\\

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -16,7 +16,7 @@ apt install -f -y ca-certificates-java
 PKG_LIST="apt-utils default-jre-headless socat ethtool iproute2 net-tools procps \
 libpcap-dev openssl libssl-dev libbpf-dev bpftool \
 zip unzip wget psmisc busybox \
-telnet tshark nmap iperf vim"
+telnet tshark nmap iperf vim ed"
 
 apt-get -f -y --no-install-recommends install $PKG_LIST
 

--- a/install-rtr.sh
+++ b/install-rtr.sh
@@ -47,6 +47,7 @@ echo kernel.panic=10 > /etc/sysctl.d/panic.conf
 cp $TMP/src/rtr.jar $TRG/
 cp $TMP/src/rtr.ver $TRG/
 cp $TMP/binTmp/*.bin $TRG/
+cp $TMP/binTmp/*.so $TRG/
 
 sync
 


### PR DESCRIPTION
Add support for p4emu dataplane and dynamic configuration via DATAPLANE_TYPE
- Allow switching between pcapInt (default) and p4emu dataplanes using the DATAPLANE_TYPE environment variable
- Automatically migrate and adapt configuration when changing dataplane type
- Ensure the interfaces are automatically exported into the p4 server