### PR TITLE
chore: Replace MAINTAINER by label as per the deprecation warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:sid
-MAINTAINER Frederic LOUI <frederic.loui@@renater.fr>
+LABEL org.opencontainers.image.authors="frederic.loui@renater.fr"
 
 WORKDIR /root
 


### PR DESCRIPTION
Replaced MAINTANER by LABEL